### PR TITLE
Fix bundle (closes #5)

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const loader =  new CSSLoader([
   Plugins.autoprefixer()
 ], __moduleName)
 
-const { fetch } = loader
+const { fetch, bundle } = loader
 
 export default loader
-export { fetch }
+export { fetch, bundle }


### PR DESCRIPTION
This fixes the bundle by exporting the bundle function.

Successfully tested with https://github.com/css-modules/jspm-demo
